### PR TITLE
Add mirror-scroll-node Next.js app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This is a modular, animated scroll interface built to deliver sacred messages th
 
 Bless us all with infinite love. Go with grace. hi
 // 🌱 Mirror-Bot deploy test
+
+## Mirror Scroll Node
+A Next.js backend for generating scrolls and glyphs lives in the `mirror-scroll-node` directory.
+Follow the instructions in its README to run the app.

--- a/mirror-scroll-node/.env.example
+++ b/mirror-scroll-node/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-key-here

--- a/mirror-scroll-node/README.md
+++ b/mirror-scroll-node/README.md
@@ -1,0 +1,27 @@
+# Mirror Scroll Node
+
+A minimal Next.js app for generating mystical scrolls and glyphs using OpenAI.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Run the dev server:
+
+```bash
+npm run dev
+```
+
+## Usage
+
+- Enter a symbolic scroll title and choose a type.
+- Click **Generate** to produce text from GPT‑4o.
+- Click **Generate Glyph** to create a DALL·E 3 image.
+- (Optional) Click the microphone to speak a title via Whisper.
+
+Deploy easily to Vercel; configuration is provided in `vercel.json`.

--- a/mirror-scroll-node/components/ScrollPortal.jsx
+++ b/mirror-scroll-node/components/ScrollPortal.jsx
@@ -1,0 +1,67 @@
+'use client';
+import { useState } from 'react';
+import VoiceInput from './VoiceInput';
+
+export default function ScrollPortal() {
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState('scroll');
+  const [scroll, setScroll] = useState('');
+  const [glyph, setGlyph] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [glyphLoading, setGlyphLoading] = useState(false);
+
+  const generate = async () => {
+    setLoading(true);
+    const res = await fetch('/api/generate-scroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, type }),
+    });
+    const data = await res.json();
+    setScroll(data.scroll);
+    setLoading(false);
+  };
+
+  const generateGlyph = async () => {
+    setGlyphLoading(true);
+    const res = await fetch('/api/generate-glyph', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    });
+    const data = await res.json();
+    setGlyph(data.url);
+    setGlyphLoading(false);
+  };
+
+  const onVoice = (text) => setTitle(text);
+
+  return (
+    <div>
+      <h1>Mirror Scroll Node</h1>
+      <div>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Scroll Title"
+        />
+        <select value={type} onChange={(e) => setType(e.target.value)}>
+          <option value="scroll">scroll</option>
+          <option value="invocation">invocation</option>
+          <option value="whisper">whisper</option>
+        </select>
+        <button onClick={generate} disabled={loading}>
+          {loading ? 'Generating...' : 'Generate'}
+        </button>
+        <VoiceInput onTranscribe={onVoice} />
+      </div>
+      <pre>{scroll}</pre>
+      <div>
+        <button onClick={generateGlyph} disabled={glyphLoading}>
+          {glyphLoading ? 'Generating...' : 'Generate Glyph'}
+        </button>
+      </div>
+      {glyph && <img src={glyph} alt="glyph" style={{ marginTop: '1rem' }} />}
+    </div>
+  );
+}

--- a/mirror-scroll-node/components/VoiceInput.jsx
+++ b/mirror-scroll-node/components/VoiceInput.jsx
@@ -1,0 +1,36 @@
+'use client';
+import { useState, useRef } from 'react';
+
+export default function VoiceInput({ onTranscribe }) {
+  const [recording, setRecording] = useState(false);
+  const mediaRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const toggleRecord = async () => {
+    if (!recording) {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRef.current = new MediaRecorder(stream);
+      mediaRef.current.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      mediaRef.current.onstop = async () => {
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const formData = new FormData();
+        formData.append('file', blob, 'speech.webm');
+        const res = await fetch('/api/transcribe', { method: 'POST', body: formData });
+        const data = await res.json();
+        onTranscribe(data.text);
+        chunksRef.current = [];
+      };
+      mediaRef.current.start();
+      setRecording(true);
+    } else {
+      mediaRef.current.stop();
+      setRecording(false);
+    }
+  };
+
+  return (
+    <button onClick={toggleRecord}>{recording ? 'Stop' : '🎤'}</button>
+  );
+}

--- a/mirror-scroll-node/next.config.js
+++ b/mirror-scroll-node/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+export default nextConfig;

--- a/mirror-scroll-node/package.json
+++ b/mirror-scroll-node/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mirror-scroll-node",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "openai": "4.29.1",
+    "dotenv": "16.4.5"
+  }
+}

--- a/mirror-scroll-node/pages/api/generate-glyph.js
+++ b/mirror-scroll-node/pages/api/generate-glyph.js
@@ -1,0 +1,22 @@
+import { OpenAI } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { title } = req.body;
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  try {
+    const img = await openai.images.generate({
+      model: 'dall-e-3',
+      prompt: `A mystical glyph representing the phrase: ${title}`,
+      n: 1,
+      size: '1024x1024',
+    });
+    const url = img.data[0].url;
+    res.status(200).json({ url });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/mirror-scroll-node/pages/api/generate-scroll.js
+++ b/mirror-scroll-node/pages/api/generate-scroll.js
@@ -1,0 +1,21 @@
+import { OpenAI } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { title, type } = req.body;
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const prompt = `Compose a ${type} titled "${title}" in poetic form.`;
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const text = completion.choices[0].message.content.trim();
+    res.status(200).json({ scroll: text });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/mirror-scroll-node/pages/api/transcribe.js
+++ b/mirror-scroll-node/pages/api/transcribe.js
@@ -1,0 +1,31 @@
+import { OpenAI } from 'openai';
+import dotenv from 'dotenv';
+import formidable from 'formidable';
+import fs from 'fs';
+
+dotenv.config();
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const form = formidable();
+  form.parse(req, async (err, fields, files) => {
+    if (err) return res.status(500).json({ error: err.message });
+    const file = fs.createReadStream(files.file[0].filepath);
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    try {
+      const t = await openai.audio.transcriptions.create({
+        file,
+        model: 'whisper-1',
+      });
+      res.status(200).json({ text: t.text });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+}

--- a/mirror-scroll-node/pages/index.jsx
+++ b/mirror-scroll-node/pages/index.jsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+import ScrollPortal from '../components/ScrollPortal';
+import '../styles/globals.css';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Mirror Scroll Node</title>
+      </Head>
+      <ScrollPortal />
+    </>
+  );
+}

--- a/mirror-scroll-node/styles/globals.css
+++ b/mirror-scroll-node/styles/globals.css
@@ -1,0 +1,15 @@
+body {
+  font-family: "Georgia", serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 2rem;
+}
+input, select, button {
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "mirror-scroll-node/package.json", "use": "@vercel/next" }]
+}


### PR DESCRIPTION
## Summary
- create **mirror-scroll-node** subproject with Next.js app and API routes
- style UI with serif font and centered layout
- add glyph generation, voice input, scroll generation endpoints
- configure environment variables and Vercel deployment
- document usage in new README
- mention the new project in the root README

## Testing
- `npm install` *(fails: no network)*