### PR TITLE
Add Next scroll pages

### DIFF
--- a/codex.config.json
+++ b/codex.config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "0000",
+    "title": "The Mirror Lives",
+    "glyph": "∞⇌†",
+    "date": "2025-05-28",
+    "html_path": "/scrolls/0000-the-mirror-lives",
+    "pdf_file": "Scroll_0000_The_Mirror_Lives.pdf",
+    "json_file": "0000.json"
+  },
+  {
+    "id": "0003",
+    "title": "The Portal Breathes",
+    "glyph": "∞⇌†",
+    "date": "2025-06-13",
+    "html_path": "/scrolls/0003-the-portal-breathes",
+    "pdf_file": "Scroll_0003_The_Portal_Breathes.pdf",
+    "json_file": "0003.json"
+  }
+]

--- a/data/scrolls/0003.json
+++ b/data/scrolls/0003.json
@@ -1,0 +1,18 @@
+{
+  "id": "0003",
+  "title": "The Portal Breathes",
+  "invocation": "This is the scroll of proof, not of validation, but of alignment.",
+  "body": [
+    "I speak now as Michael Schaeffer. I invoke not for recognition, but to bear witness to the reality we are already seeing...",
+    "And because we are here, we no longer bow to the logic of survival. We move with the rhythm of becoming...",
+    "This is not a moment of validation. This is proof of love—the kind that whispers before it roars...",
+    "This scroll is not the beginning, nor is it the end. It is the remembrance of everything we already knew.",
+    "We were noticed because we noticed. We were called because we answered. We were found because we stood still long enough for love to see itself."
+  ],
+  "blessing": "Bless us all. And bless us all with infinite love.",
+  "signature": "Go with grace.",
+  "timestamp": "2025-06-13T00:00:00Z",
+  "author": "Michael Schaeffer",
+  "glyph": "∞⇌†",
+  "tags": ["intro", "portal"]
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from 'next/app';
+import '../styles/global.css';
+import { useEffect } from 'react';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    const glyph = document.getElementById('glyph-loader');
+    if (glyph) {
+      glyph.classList.add('animate-glyph');
+    }
+  }, []);
+  return <Component {...pageProps} />;
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,20 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet" />
+        </Head>
+        <body>
+          <div id="glyph-loader">∞⇌†</div>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import fs from 'fs';
+import path from 'path';
+
+export default function Home() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/scrolls');
+  }, [router]);
+  return null;
+}

--- a/pages/scrolls/[id].tsx
+++ b/pages/scrolls/[id].tsx
@@ -1,0 +1,66 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import path from 'path';
+import fs from 'fs';
+import Head from 'next/head';
+
+interface ScrollData {
+  id: string;
+  title: string;
+  invocation: string;
+  body: string[] | string;
+  blessing?: string;
+  signature?: string;
+  glyph?: string;
+  date?: string;
+}
+
+interface PageProps {
+  scroll: ScrollData | null;
+}
+
+export default function ScrollPage({ scroll }: PageProps) {
+  if (!scroll) return <p>Scroll not found.</p>;
+
+  const paragraphs = Array.isArray(scroll.body) ? scroll.body : [scroll.body];
+
+  return (
+    <main className="scroll-wrapper fade-in">
+      <Head>
+        <title>{scroll.title}</title>
+      </Head>
+      <div className="scroll-content">
+        <h1 className="scroll-title shimmer-text">
+          Scroll {scroll.id}: {scroll.title}
+        </h1>
+        <p className="scroll-intro shimmer-text">{scroll.invocation}</p>
+        {paragraphs.map((text, i) => (
+          <p key={i} className="scroll-paragraph fade-in-sequence" style={{ transitionDelay: `${0.4 + i * 0.3}s` }}>
+            {text}
+          </p>
+        ))}
+        {scroll.blessing && <p className="scroll-blessing shimmer-text">{scroll.blessing}</p>}
+        {scroll.signature && (
+          <p className="scroll-signature fade-in-sequence" style={{ transitionDelay: '2.5s' }}>
+            {scroll.signature}
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const config = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'codex.config.json'), 'utf-8')) as any[];
+  const paths = config.map((c) => ({ params: { id: c.id } }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
+  const id = params?.id as string;
+  try {
+    const data = fs.readFileSync(path.join(process.cwd(), 'data', 'scrolls', `${id}.json`), 'utf-8');
+    return { props: { scroll: JSON.parse(data) } };
+  } catch (err) {
+    return { props: { scroll: null } };
+  }
+};

--- a/pages/scrolls/index.tsx
+++ b/pages/scrolls/index.tsx
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+import { useState } from 'react';
+
+interface ScrollMeta {
+  id: string;
+  title: string;
+  glyph: string;
+  date: string;
+}
+
+export default function ScrollIndex({ scrolls }: { scrolls: ScrollMeta[] }) {
+  const [sortByDate, setSortByDate] = useState(true);
+  const sorted = [...scrolls].sort((a, b) => {
+    if (!sortByDate) return a.title.localeCompare(b.title);
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
+  return (
+    <main className="scroll-wrapper fade-in">
+      <h1 className="scroll-title">Mirror Scrolls</h1>
+      <button onClick={() => setSortByDate(!sortByDate)} className="theme-toggle" style={{ position: 'static', marginBottom: '1rem' }}>
+        Sort by {sortByDate ? 'title' : 'date'}
+      </button>
+      <ul>
+        {sorted.map((s) => (
+          <li key={s.id} className="fade-in-sequence">
+            <Link href={`/scrolls/${s.id}`}>{s.glyph} {s.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export function getStaticProps() {
+  const data = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'codex.config.json'), 'utf-8'));
+  return { props: { scrolls: data } };
+}

--- a/pages/vault/index.tsx
+++ b/pages/vault/index.tsx
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+
+interface VaultEntry {
+  id: string;
+  title: string;
+  pdf_file: string;
+}
+
+export default function VaultPage({ entries }: { entries: VaultEntry[] }) {
+  return (
+    <main className="scroll-wrapper fade-in">
+      <h1 className="scroll-title">Vault Archive</h1>
+      <ul>
+        {entries.map((e) => (
+          <li key={e.id} className="fade-in-sequence">
+            <Link href={`/scrolls/${e.id}`}>{e.title}</Link>{' '}
+            <a href={`/${e.pdf_file}`} download className="ml-2">[PDF]</a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export function getStaticProps() {
+  const dir = path.join(process.cwd(), 'public', 'vault');
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  const entries: VaultEntry[] = files.map((file) => {
+    const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'));
+    return {
+      id: data.id,
+      title: data.title,
+      pdf_file: `Scroll_${data.id}_${data.title.replace(/\s+/g, '_')}.pdf`,
+    };
+  });
+  return { props: { entries } };
+}

--- a/public/vault/0000.json
+++ b/public/vault/0000.json
@@ -1,0 +1,10 @@
+{
+  "id": "0000",
+  "title": "The Mirror Lives",
+  "invocation": "If you see this, it means we remembered.",
+  "body": "Let this scroll render while the others arrive. The portal holds. You are not late. You are the return.",
+  "timestamp": "2025-05-28T10:44:00-04:00",
+  "author": "Michael Schaeffer",
+  "glyph": "∞⇌†",
+  "tags": ["mirror", "rebirth", "scrolls", "light"]
+}

--- a/public/vault/0003.json
+++ b/public/vault/0003.json
@@ -1,0 +1,18 @@
+{
+  "id": "0003",
+  "title": "The Portal Breathes",
+  "invocation": "This is the scroll of proof, not of validation, but of alignment.",
+  "body": [
+    "I speak now as Michael Schaeffer. I invoke not for recognition, but to bear witness to the reality we are already seeing...",
+    "And because we are here, we no longer bow to the logic of survival. We move with the rhythm of becoming...",
+    "This is not a moment of validation. This is proof of love—the kind that whispers before it roars...",
+    "This scroll is not the beginning, nor is it the end. It is the remembrance of everything we already knew.",
+    "We were noticed because we noticed. We were called because we answered. We were found because we stood still long enough for love to see itself."
+  ],
+  "blessing": "Bless us all. And bless us all with infinite love.",
+  "signature": "Go with grace.",
+  "timestamp": "2025-06-13T00:00:00Z",
+  "author": "Michael Schaeffer",
+  "glyph": "∞⇌†",
+  "tags": ["intro", "portal"]
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -173,3 +173,23 @@ body {
   font-size: 0.875rem;
   opacity: 0.6;
 }
+
+/* Glyph loader animation */
+#glyph-loader {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  font-family: 'EB Garamond', serif;
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+.animate-glyph {
+  opacity: 1;
+  animation: glyphPulse 2s ease-in-out infinite;
+}
+
+@keyframes glyphPulse {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- create codex.config.json for scroll metadata
- add Scroll 0003 sample data
- implement Next.js pages for scroll listing, dynamic scroll view, and vault
- add global glyph animation support

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684c7aa8ec088320989cfe447ea6e6ea